### PR TITLE
Zappastuff hkx

### DIFF
--- a/Readme.MD
+++ b/Readme.MD
@@ -13,7 +13,8 @@ There are several external tools that are used by my scripts to get things done.
 - `XTX-Extractor` was created by AboodXD  
   <https://github.com/aboood40091> and is available here  
   <https://github.com/aboood40091/XTX-Extractor>
-- `nx_fuz.py` was written by Zappastuff
+- `nx_fuz.py` was written by Zappastuff <https://github.com/thywoof>
+- `convert_hkx64.py` was written by Zappastuff <https://github.com/thywoof>
 
 There are further external tools that the toolkit will attempt to download if you don't have them in the `Utilities` directory, or that you must source yourself.
 These tools are:

--- a/Scripts/convert_hkx64.py
+++ b/Scripts/convert_hkx64.py
@@ -2,7 +2,7 @@
 #
 # by Zappastuff - 02-19-19
 #
-# convert XBOX HKX to PS4 / SWITCH format
+# convert 64-bit SSE HKX to PS4 / SWITCH format
 #
 # DOESN'T WORK for these animation files:
 #

--- a/Scripts/convert_hkx64.py
+++ b/Scripts/convert_hkx64.py
@@ -1,0 +1,52 @@
+#! python3
+#
+# by Zappastuff - 02-19-19
+#
+# convert XBOX HKX to PS4 / SWITCH format
+#
+# DOESN'T WORK for these animation files:
+#
+# skeleton.hkx
+# skeleton_female.hkx
+# behaviors HKX (i.e: 0_master.hkx and 1hm_behavior.hkx) usually under a behaviors folder
+# FNIS generated behavior files (you can always run FNIS 32 for Modders to recreate them in 32 bit)
+
+import sys
+import re
+import os.path
+import sizes
+import util
+import shutil
+
+import subprocess
+
+def ConvertHKX64_Internal(filename):
+	util.LogDebug("ConvertHKX64 : " + filename)
+
+	hkx64 = open(filename, "rb")
+	payload = hkx64.read()
+	hkx64.close()	
+
+	magic = b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x80\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+
+	found = payload.find(magic)
+
+	# swap some fields in the AMD64 HKX header structure to make it PS4 compatible
+	if found > 0:	
+		hkxPS4 = open(filename, "wb")
+		hkxPS4.write(payload[0:18])
+		hkxPS4.write(b'\x01')
+		hkxPS4.write(payload[19:found+16])
+		hkxPS4.write(payload[found+20:found+80])
+		hkxPS4.write(payload[found:found+4])
+		hkxPS4.write(payload[found+80:])
+		hkxPS4.close() 
+	
+	return True
+
+def ConvertHKX64(target, filename):
+	return ConvertHKX64_Internal(filename)
+	
+if __name__ == '__main__':
+	filename = sys.argv[1]
+	ConvertHKX64_Internal(filename)

--- a/Scripts/convert_path.py
+++ b/Scripts/convert_path.py
@@ -8,7 +8,7 @@ import util
 import job_manager
 import toolkit_config
 import check_dds, convert_dds
-import check_hkx, convert_hkx
+import check_hkx, convert_hkx, convert_hkx64
 import convert_txt
 import convert_sound
 
@@ -29,6 +29,7 @@ def ConvertPath(mod_name, target):
 	WarnConversion = {}
 	ConvertListDDS = []
 	ConvertListHKX = []
+	ConvertListHKX64 = []
 	ConvertListTXT = []
 	ConvertListSound = []
 	for root, subdirs, files in os.walk(target):
@@ -57,9 +58,12 @@ def ConvertPath(mod_name, target):
 					elif hkxChecked == check_hkx.PC_XML:
 						ConvertListHKX.append(file_path)
 					elif hkxChecked == check_hkx.PC_64:
-						if 'HKX' not in WarnConversion:
-							WarnConversion['HKX'] = []
-						WarnConversion['HKX'].append( (filename, "SSE hkx animation") )
+						if root.lower().find("behaviors") > 0 or filename.lower().find("skeleton") > 0:
+							if 'HKX' not in WarnConversion:
+								WarnConversion['HKX'] = []
+							WarnConversion['HKX'].append( (filename, "SSE hkx animation") )
+						else:
+							ConvertListHKX64.append(file_path)
 					elif hkxChecked == check_hkx.NX_64:
 						if 'HKX' not in NoConversion:
 							NoConversion['HKX'] = 0
@@ -85,6 +89,7 @@ def ConvertPath(mod_name, target):
 			
 	util.LogInfo("Found {} dds files to convert".format(len(ConvertListDDS)))
 	if has_havoc: util.LogInfo("Found {} hkx files to convert".format(len(ConvertListHKX)))
+	util.LogInfo("Found {} 64 hkx files to convert".format(len(ConvertListHKX64)))	
 	util.LogInfo("Found {} txt files to convert".format(len(ConvertListTXT)))
 	util.LogInfo("Found {} sound files to convert".format(len(ConvertListSound)))
 	
@@ -134,6 +139,7 @@ def ConvertPath(mod_name, target):
 	LogProgress(ConvertListDDS, convert_dds.ConvertDDS, "DDS", "MaxTextureThreads")
 	if has_havoc:
 		LogProgress(ConvertListHKX, convert_hkx.ConvertHKX, "HKX", "MaxAnimationThreads")
+	LogProgress(ConvertListHKX64, convert_hkx64.ConvertHKX64, "HKX64", "MaxAnimationThreads")
 	LogProgress(ConvertListTXT, convert_txt.ConvertTXT, "TXT", "MaxOtherThreads")
 	LogProgress(ConvertListSound, convert_sound.ConvertSound, "Sounds", "MaxSoundThreads")
 


### PR DESCRIPTION
Changes in the TOOLKIT to support 64-bit SSE HKX files to be converted. It will automatically skips 64-bit SSE files in any behaviors folder as well as skeleton*.hkx files. These aren't supported yet.