### PR TITLE
Collateral case to fix XWM files stored as WAV

### DIFF
--- a/Scripts/convert_sound_zappa.py
+++ b/Scripts/convert_sound_zappa.py
@@ -36,7 +36,7 @@ def WAV2DSP(filename_wav, filename_dsp0, filename_dsp1):
 		util.RemoveFile(filename_temp)
 
 	# make the WAV file compatible with VGAudioCLi
-	if wav_audio_format != 1 or wav_bits_per_sample != 8 or wav_bits_per_sample != 16:
+	if wav_audio_format != 1 or not (wav_bits_per_sample == 8 or wav_bits_per_sample == 16):
 		wav_data, wav_samplerate = soundfile.read(filename_wav)
 		soundfile.write(filename_wav, wav_data, wav_samplerate, subtype='PCM_16')
 

--- a/Scripts/convert_sound_zappa.py
+++ b/Scripts/convert_sound_zappa.py
@@ -7,30 +7,43 @@ def GetVGAudioCli():
 	utilities_path = util.GetUtilitiesPath()
 	VGAudioCli = os.path.join(utilities_path, "Sound", "VGAudioCli.exe")
 	return VGAudioCli
-	
+
 def GetxWMAEncode():
 	utilities_path = util.GetUtilitiesPath()
 	xWMAEncode = os.path.join(utilities_path, "Sound", "xWMAEncode.exe")
 	return xWMAEncode
-	
+
 def XWM2WAV(filename_xwm, filename_wav):
 	xWMAEncode = GetxWMAEncode()
 	commandLine = [xWMAEncode, filename_xwm, filename_wav]
 	util.RunCommandLine(commandLine)
-	
+
 def WAV2DSP(filename_wav, filename_dsp0, filename_dsp1):
 	with open(filename_wav, "rb") as wav_file:
-		wav_file.seek(0x16)
-		channel_count = int.from_bytes(wav_file.read(1), byteorder = 'little', signed = False)
-		
-	VGAudioCli = GetVGAudioCli()
-	commandLine = [VGAudioCli, "-i:0", filename_wav, filename_dsp0]
-	util.RunCommandLine(commandLine)
-	if channel_count > 1:
-		commandLine = [VGAudioCli, "-i:1", filename_wav, filename_dsp1]
+		wav_header = wav_file.read(0x17)
+		wav_signature = wav_header[0x08:0x0F].decode()
+		channel_count = wav_header[-1]
+
+	# checking for collateral case where Mod Authors save XWM with WAV filepath_without_extension
+	if wav_signature == "XWMAfmt":
+		util.LogDebug("<{}> has WAV extension but is a XWMA. Fixing.".format(filename_wav))
+		filename_temp = filename_wav + ".TEMP"
+		util.RenameFile(filename_wav, filename_temp)
+		XWM2WAV(filename_temp, filename_wav)
+		util.RemoveFile(filename_temp)
+
+	# only create DSP if a valid WAVE format is found
+	if wav_signature == "WAVEfmt":
+		VGAudioCli = GetVGAudioCli()
+		commandLine = [VGAudioCli, "-i:0", filename_wav, filename_dsp0]
 		util.RunCommandLine(commandLine)
-		channel_count = 2
-	
+		if channel_count > 1:
+			commandLine = [VGAudioCli, "-i:1", filename_wav, filename_dsp1]
+			util.RunCommandLine(commandLine)
+			channel_count = 2
+	else:
+		channel_count = -1
+
 	return channel_count
 
 def ConvertDSP(dsp_data, base):
@@ -57,8 +70,8 @@ def DSP2MCADPCM(filename_dsp0, filename_dsp1, channels, sound_file):
 		sound_file.write(dsp1_size.to_bytes(4, byteorder = 'little', signed = False))
 		sound_file.write(dsp0_data)
 		sound_file.write(dsp1_data)
-		
-	else:
+
+	elif channels == 1:
 		header_single = b'\x01\x00\x00\x00\x0C\x00\x00\x00'
 		sound_file.write(header_single)
 		sound_file.write(dsp0_size.to_bytes(4, byteorder = 'little', signed = False))
@@ -67,7 +80,7 @@ def DSP2MCADPCM(filename_dsp0, filename_dsp1, channels, sound_file):
 def ConvertSound_Internal(filepath_without_extension):
 	filename_mcadpcm = filepath_without_extension + ".mcadpcm"
 	filename_dsp0 = filepath_without_extension + "_CH0_.dsp"
-	filename_dsp1 = filepath_without_extension + "_CH1_.dsp"	
+	filename_dsp1 = filepath_without_extension + "_CH1_.dsp"
 	filename_wav = filepath_without_extension + ".wav"
 	filename_xwm = filepath_without_extension + ".xwm"
 	filename_lip = filepath_without_extension + ".lip"
@@ -80,10 +93,7 @@ def ConvertSound_Internal(filepath_without_extension):
 
 	util.LogDebug("Convert Sound <{}> WAV:{} XWM:{} LIP:{} FUZ:{}".format(filepath_without_extension, has_wav, has_xwm, has_lip, has_fuz))
 
-	# try to find a LIP and convert sound to DSP
-	#  - loose WAV files take precedence over FUZ or XWM
-	#  - loose XWM files take precedence over FUZ
-	#  - loose LIP files take precedence over FUZ
+	# if there is a loose LIP load into memory
 	if has_lip:
 		with open(filename_lip, "rb") as lip_file:
 			lip_data = lip_file.read()
@@ -91,6 +101,9 @@ def ConvertSound_Internal(filepath_without_extension):
 	else:
 		lip_size = 0
 
+	#  - loose WAV files take precedence over FUZ or XWM
+	#  - loose XWM files take precedence over FUZ
+	#  - loose LIP files take precedence over FUZ
 	if has_fuz and (lip_size == 0 or not (has_wav or has_xwm)):
 		with open(filename_fuz, "rb") as fuz_file:
 			if lip_size == 0:
@@ -98,48 +111,51 @@ def ConvertSound_Internal(filepath_without_extension):
 				lip_size = int.from_bytes(fuz_file.read(0x04), byteorder = 'little', signed = False)
 				lip_data = fuz_file.read(lip_size)
 			else:
-				fuz_file.seek(0x12)				
+				fuz_file.seek(0x12)
 			if not (has_wav or has_xwm):
 				with open(filename_xwm, "wb") as xwm_file:
 					xwm_file.write(fuz_file.read())
 					has_xwm = True
-			
+
+	# try to reuse existing WAV whenever possible to avoid too many conversions
 	if not has_wav:
 		XWM2WAV(filename_xwm, filename_wav)
 
+	# it returns -1 on a failed conversion
 	channels = WAV2DSP(filename_wav, filename_dsp0, filename_dsp1)
 
-	# convert DSP to MCADPCM and save as MCADPCM or as FUZ if there is a LIP
-	if lip_size > 0:
-		lip_padding = lip_size % 4
-		if lip_padding != 0: lip_padding = 4 - lip_padding
-		voice_offset = 0x10 + lip_size + lip_padding
-		
-		with open(filename_fuz, "wb") as fuz_nx_file:
-			header_fuz = b'\x46\x55\x5A\x45\x01\x00\x00\x00'
-			fuz_nx_file.write(header_fuz)
-			fuz_nx_file.write(lip_size.to_bytes(4, byteorder = 'little', signed = False))
-			fuz_nx_file.write(voice_offset.to_bytes(4, byteorder = 'little', signed = False))
-			fuz_nx_file.write(lip_data)
-			fuz_nx_file.write(b'\x00' * lip_padding)
-			DSP2MCADPCM(filename_dsp0, filename_dsp1, channels, fuz_nx_file)			
-	else:
-		with open(filename_mcadpcm, "wb") as mcadpcm_file:
-			DSP2MCADPCM(filename_dsp0, filename_dsp1, channels, mcadpcm_file)
+	# only proceed if previous conversion was successful
+	if channels > 0:
+		if lip_size > 0:
+			lip_padding = lip_size % 4
+			if lip_padding != 0: lip_padding = 4 - lip_padding
+			voice_offset = 0x10 + lip_size + lip_padding
 
-	# clean up temporary files	
-	util.RemoveFile(filename_wav) 
-	util.RemoveFile(filename_dsp0)
-	if channels == 2: util.RemoveFile(filename_dsp1)
+			with open(filename_fuz, "wb") as fuz_nx_file:
+				header_fuz = b'\x46\x55\x5A\x45\x01\x00\x00\x00'
+				fuz_nx_file.write(header_fuz)
+				fuz_nx_file.write(lip_size.to_bytes(4, byteorder = 'little', signed = False))
+				fuz_nx_file.write(voice_offset.to_bytes(4, byteorder = 'little', signed = False))
+				fuz_nx_file.write(lip_data)
+				fuz_nx_file.write(b'\x00' * lip_padding)
+				DSP2MCADPCM(filename_dsp0, filename_dsp1, channels, fuz_nx_file)
+		else:
+			with open(filename_mcadpcm, "wb") as mcadpcm_file:
+				DSP2MCADPCM(filename_dsp0, filename_dsp1, channels, mcadpcm_file)
+
+	# clean up temporary files
+	util.RemoveFile(filename_wav)
+	if channels > 0: util.RemoveFile(filename_dsp0)
+	if channels > 1: util.RemoveFile(filename_dsp1)
 	if has_xwm: util.RemoveFile(filename_xwm)
 	if has_lip: util.RemoveFile(filename_lip)
 	if lip_size == 0: util.RemoveFile(filename_fuz)
-	
-	return True
-	
+
+	return (channels > 0)
+
 def ConvertSound(target, filepath_without_extension):
 	return ConvertSound_Internal(filepath_without_extension)
-	
+
 if __name__ == '__main__':
 	import sys
 	filepath = sys.argv[1]

--- a/Scripts/convert_sound_zappa.py
+++ b/Scripts/convert_sound_zappa.py
@@ -35,8 +35,8 @@ def WAV2DSP(filename_wav, filename_dsp0, filename_dsp1):
 		XWM2WAV(filename_temp, filename_wav)
 		util.RemoveFile(filename_temp)
 
-	# make the WAV file compatible with VGAudioCLi
-	if wav_audio_format != 1 or not (wav_bits_per_sample == 8 or wav_bits_per_sample == 16):
+	# make the WAV file compatible with VGAudioCLi whenever required
+	elif wav_audio_format != 1 or not (wav_bits_per_sample == 8 or wav_bits_per_sample == 16):
 		util.LogInfo("Warning, <{}> isn't compatible with VGAudioCLi. Fixing.".format(filename_wav))
 		wav_data, wav_samplerate = soundfile.read(filename_wav)
 		soundfile.write(filename_wav, wav_data, wav_samplerate, subtype='PCM_16')

--- a/Scripts/convert_sound_zappa.py
+++ b/Scripts/convert_sound_zappa.py
@@ -29,7 +29,7 @@ def WAV2DSP(filename_wav, filename_dsp0, filename_dsp1):
 
 	# checking for a collateral case where Mod Authors save XWM with WAV extension
 	if wav_format == "XWMA":
-		util.LogDebug("<{}> has WAV extension but is a XWMA. Fixing.".format(filename_wav))
+		util.LogInfo("Warning, <{}> has WAV extension but is a XWMA. Fixing.".format(filename_wav))
 		filename_temp = filename_wav + ".TEMP"
 		util.RenameFile(filename_wav, filename_temp)
 		XWM2WAV(filename_temp, filename_wav)
@@ -37,6 +37,7 @@ def WAV2DSP(filename_wav, filename_dsp0, filename_dsp1):
 
 	# make the WAV file compatible with VGAudioCLi
 	if wav_audio_format != 1 or not (wav_bits_per_sample == 8 or wav_bits_per_sample == 16):
+		util.LogInfo("Warning, <{}> isn't compatible with VGAudioCLi. Fixing.".format(filename_wav))
 		wav_data, wav_samplerate = soundfile.read(filename_wav)
 		soundfile.write(filename_wav, wav_data, wav_samplerate, subtype='PCM_16')
 


### PR DESCRIPTION
Some mod authors save XWM files with a WAV extension. This isn't an issue on PC as Skyrim will always check for the sound signature to use the correct codec. Added an additional check to verify if a WAV is indeed one. If a XWM is found it will convert to WAV before moving ahead. If anything else is found it won't create the DSP and return a false status from main conversion routine.