### PR TITLE
Deferring soundfile import to the last minute

### DIFF
--- a/Scripts/convert_sound_zappa.py
+++ b/Scripts/convert_sound_zappa.py
@@ -2,7 +2,6 @@
 
 import os
 import util
-import soundfile
 
 def GetVGAudioCli():
 	utilities_path = util.GetUtilitiesPath()
@@ -37,6 +36,7 @@ def WAV2DSP(filename_wav, filename_dsp0, filename_dsp1):
 
 	# make the WAV file compatible with VGAudioCLi whenever required
 	elif wav_audio_format != 1 or not (wav_bits_per_sample == 8 or wav_bits_per_sample == 16):
+		import soundfile
 		util.LogInfo("Warning, <{}> isn't compatible with VGAudioCLi. Fixing.".format(filename_wav))
 		wav_data, wav_samplerate = soundfile.read(filename_wav)
 		soundfile.write(filename_wav, wav_data, wav_samplerate, subtype='PCM_16')


### PR DESCRIPTION
Only import soundfile on very rare collateral conditions. This is a hack, better to correctly setup PyInstaller specs to include the required soundfile DLL. This should alleviate the issue users running the EXE are facing now. 