### PR TITLE
LOAD_ORDER wasn't handling multi-assets use case

### DIFF
--- a/Scripts/load_order.py
+++ b/Scripts/load_order.py
@@ -182,7 +182,7 @@ def LoadOrder(origin, target, loadOrderName):
 					InsertTestFile(file, filename)
 				elif re.match(".*Textures[0-9]?.bsa$", file):
 					InsertLanguageBSA(file, filename)
-				elif re.match(".*Voices.[0-9]?.bsa$", file):
+				elif re.match(".*Voices[0-9]?.bsa$", file):
 				elif file.endswith("Animations.bsa"):
 					InsertInMemoryBSA(file, filename)
 				elif file.endswith(".bsa"):

--- a/Scripts/load_order.py
+++ b/Scripts/load_order.py
@@ -180,10 +180,9 @@ def LoadOrder(origin, target, loadOrderName):
 				filename = os.path.join(pluginFolder, file)
 				if file.endswith(".esm") or file.endswith(".esp"):
 					InsertTestFile(file, filename)
-				elif file.endswith("Textures.bsa"):
+				elif re.match(".*Textures[0-9]?.bsa$", file):
 					InsertLanguageBSA(file, filename)
-				elif file.endswith("Voices.bsa"):
-					InsertLanguageBSA(file, filename)
+				elif re.match(".*Voices.[0-9]?.bsa$", file):
 				elif file.endswith("Animations.bsa"):
 					InsertInMemoryBSA(file, filename)
 				elif file.endswith(".bsa"):


### PR DESCRIPTION
Conversion tool produce files using patterns .*Textures[0-9]?.bsa and .*Voices[0-9]?.bsa but routine wasn't considering when a Mod had more than one asset file of same type.