### PR TITLE
Fix to TestFile lines

### DIFF
--- a/Scripts/packed_load_order.py
+++ b/Scripts/packed_load_order.py
@@ -180,7 +180,7 @@ def LoadOrder(origin, target, loadOrderName):
 			for file in os.listdir(pluginFolder):
 				util.LogDebug("   Found " + file)
 				filename = os.path.join(pluginFolder, file)
-				if file.endswith(".esm") or file.endswith(".esp"):
+				if file.endswith(".esm"):
 					InsertTestFile(file, filename)
 				elif file.endswith(".ini"):
 					InsertIni(filename)


### PR DESCRIPTION
Fixed an error where PY_PACKED_LOAD_ORDER.BAT crashed if you had too many mods for the 10 sTestFile lines due to also adding .ESP files there.